### PR TITLE
fix: add underscore to isAlpha

### DIFF
--- a/jq.js
+++ b/jq.js
@@ -34,7 +34,7 @@ function compileNode(prog) {
 }
 
 function isAlpha(c) {
-    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c === '_'
 }
 
 function isDigit(c) {


### PR DESCRIPTION
Hi,

I noticed that `isAlpha` would fail if there was a key that contained an underscore.

For example, with the following data:

```json
{
  "my_data": 123
}
```

This does not generate the proper output
```javascript
let prog = jq.compile(".my_data")
let my_data = prog(foo)
```
